### PR TITLE
Save Power Data Every Minute

### DIFF
--- a/services/pijuice/power_app.py
+++ b/services/pijuice/power_app.py
@@ -18,6 +18,7 @@ class Power:
         self.time_sec = time_sec
         self.uid = int(uid)
         self.gid = int(gid)
+        self.timestamp = self.time_sec()
 
     def _time_sec(self):
         return int(time.time())

--- a/services/pijuice/power_app.py
+++ b/services/pijuice/power_app.py
@@ -35,10 +35,10 @@ class Power:
             for key in data.keys():
                 record = {"target":key, "datapoints": data[key]}
                 f.write(f'{json.dumps(record)}\n')
-        self.rename_dotfiles()
 
     def init_data(self):
         self.timestamp = self.time_sec()
+        self.rename_dotfiles()
         pijuice_data = {"battery_charge": [],
                         "battery_voltage": [],
                         "battery_current": [],
@@ -142,7 +142,7 @@ class Power:
                 data = self.get_data(pj, data)
                 self.write_data(data)
                 if write_cycles == 15:  # write out every 15 minutes
-                    self.write_data(data)
+                    #self.write_data(data)
                     data = self.init_data()
                     write_cycles = 1
                 write_cycles += 1

--- a/services/pijuice/power_app.py
+++ b/services/pijuice/power_app.py
@@ -27,6 +27,8 @@ class Power:
         for dotfile in glob.glob(os.path.join(self.data_dir, '.*')):
             basename = os.path.basename(dotfile)
             non_dotfile = os.path.join(self.data_dir, basename[1:])
+            if os.path.isfile(non_dotfile):
+                os.remove(non_dotfile)
             os.rename(dotfile, non_dotfile)
 
     def write_data(self, data):
@@ -35,6 +37,7 @@ class Power:
             for key in data.keys():
                 record = {"target":key, "datapoints": data[key]}
                 f.write(f'{json.dumps(record)}\n')
+        self.rename_dotfiles()
 
     def init_data(self):
         self.timestamp = self.time_sec()
@@ -141,8 +144,6 @@ class Power:
                 data = self.get_data(pj, data)
                 self.write_data(data)
                 if write_cycles == 15:  # write out every 15 minutes
-                    #self.write_data(data)
-                    self.rename_dotfiles()
                     data = self.init_data()
                     write_cycles = 1
                 write_cycles += 1

--- a/services/pijuice/power_app.py
+++ b/services/pijuice/power_app.py
@@ -38,7 +38,6 @@ class Power:
 
     def init_data(self):
         self.timestamp = self.time_sec()
-        self.rename_dotfiles()
         pijuice_data = {"battery_charge": [],
                         "battery_voltage": [],
                         "battery_current": [],
@@ -143,6 +142,7 @@ class Power:
                 self.write_data(data)
                 if write_cycles == 15:  # write out every 15 minutes
                     #self.write_data(data)
+                    self.rename_dotfiles()
                     data = self.init_data()
                     write_cycles = 1
                 write_cycles += 1

--- a/services/pijuice/power_app.py
+++ b/services/pijuice/power_app.py
@@ -29,16 +29,15 @@ class Power:
             os.rename(dotfile, non_dotfile)
 
     def write_data(self, data):
-        timestamp = self.time_sec()
-        tmp_filename = f'{self.data_dir}/.{self.hostname}-{timestamp}-power.json'
-        with open(tmp_filename, 'a') as f:
+        tmp_filename = f'{self.data_dir}/.{self.hostname}-{self.timestamp}-power.json'
+        with open(tmp_filename, 'w') as f:
             for key in data.keys():
                 record = {"target":key, "datapoints": data[key]}
                 f.write(f'{json.dumps(record)}\n')
         self.rename_dotfiles()
 
-    @staticmethod
-    def init_data():
+    def init_data(self):
+        self.timestamp = self.time_sec()
         pijuice_data = {"battery_charge": [],
                         "battery_voltage": [],
                         "battery_current": [],
@@ -140,6 +139,7 @@ class Power:
         while True:
             try:
                 data = self.get_data(pj, data)
+                self.write_data(data)
                 if write_cycles == 15:  # write out every 15 minutes
                     self.write_data(data)
                     data = self.init_data()


### PR DESCRIPTION
These changes cause the system to write out power data every minute and rotate log files every 15 minutes.  Present behavior stores power data in memory for 15 minutes before writing, which causes data loss if the system shuts down before 15 minutes elapses.