### PR TITLE
Added linux/arm/v8 support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,70 +48,70 @@ jobs:
       run: |
         cd services/pijuice && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-pijuice:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-pijuice:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../daisy && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-daisy:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-daisy:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../hifiberry-dac-plus-adc-pro && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-hifiberry-dac-plus-adc-pro:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-hifiberry-dac-plus-adc-pro:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../status-updater && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-status-updater:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-status-updater:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../cell-sim7600g-h && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-cell-sim7600g-h:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-cell-sim7600g-h:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../environment-sensor && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-environment-sensor:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-environment-sensor:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../s3-upload && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-s3-upload:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-s3-upload:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../compass && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-compass:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-compass:${{ steps.change_tag.outputs.IMAGE_TAG }} . && \
         cd ../sense && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-sense:${{ steps.change_version.outputs.VERSION }} \
           -t iqtlabs/pibackbone-sense:${{ steps.change_tag.outputs.IMAGE_TAG }} .
         cd ../freespacer && \
         docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64 \
+          --platform linux/arm/v6,linux/arm/v7,linux/arm/v8,linux/arm64,linux/amd64 \
           --push \
           --build-arg VERSION=${{ steps.change_version.outputs.VERSION }}.${{ steps.get_version.outputs.SHA_SHORT }} \
           -t iqtlabs/pibackbone-freespacer:${{ steps.change_version.outputs.VERSION }} \


### PR DESCRIPTION
Added linux/arm/v8 to docker buildx. Tag needed for containers.

 $ docker compose -f orchestrator.yml pull
[+] Running 1/5
 ⠿ sigfinder Skipped - Image is already being pulled by gamutrf            0.0s
 ⠿ mqtt Error                                                              0.5s
 ⠴ gamutrf Pulling                                                         0.5s
 ⠴ watchtower Pulling                                                      0.5s
 ⠿ compass Error                                                           0.5s
no matching manifest for linux/arm/v8 in the manifest list entries